### PR TITLE
GitHub Action to cargo-build

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -1,0 +1,80 @@
+name: Cargo Build
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_TARGET_DIR: ${{ github.workspace }}/build
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-latest]
+        bitness: [ 32, 64 ]
+        include:
+        - os: windows-latest
+          bitness: 32
+          target: i686-pc-windows-msvc
+        - os: windows-latest
+          bitness: 64
+          target: x86_64-pc-windows-msvc
+        exclude:
+        - os: ubuntu-22.04
+          bitness: 32
+        - os: macos-latest
+          bitness: 32
+
+    steps:
+    
+    - uses: actions/checkout@v4
+
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ matrix.os }}-${{ matrix.bitness }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install OS dependencies
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y  libasound2  libasound2-dev
+    
+    - name: Build
+      run: cargo build --release ${{ matrix.target !='' && '--target=' || ''}}${{ matrix.target }} --lib --verbose
+
+    - name: Rename Binaries Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        cd ${{ github.workspace }}/build/${{ matrix.target }}/release
+        mv TomMIDIllan.dll ../../release/TomMIDIllan_${{ matrix.bitness }}.dll
+        
+    - name: Rename Binaries Linux
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
+      run: |
+        cd ${{ github.workspace }}/build/release
+        mv libTomMIDIllan.so TomMIDIllan_${{ matrix.bitness }}.so 
+
+    - name: Rename Binaries MacOS
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        cd ${{ github.workspace }}/build/release
+        mv libTomMIDIllan.dylib TomMIDIllan_${{ matrix.bitness }}.dylib
+      
+    - name: Store Build Output
+      uses: actions/upload-artifact@v4
+      with:
+        name: LabVIEW-MIDI-XPLAT_${{ matrix.os }}-${{ matrix.bitness }}
+        path: |
+         ${{ github.workspace }}/build/**/release
+         

--- a/src/lv_midi_file.rs
+++ b/src/lv_midi_file.rs
@@ -4,7 +4,7 @@
 use std::env;
 
 // Import the Rust functions directly from our library
-use labview_midi_xplat::{
+use crate::{
     midi_file::{load_midi_file, get_midi_file, close_midi_file, EventType},
     get_note_name,
 };


### PR DESCRIPTION
Hi Tom

Here is an almost working file which will run cargo build for Windows (32 and 64 bit), Linux and MacOS and add any build files as artifacts to the workflow run.

It fails with a cargo build error - https://github.com/j-medland/LabVIEW-MIDI-XPLAT/actions/runs/16510479094/job/46691275860 for the failure

I am sure we can get it working and Github Runners have unlimited free minutes for public repos so might as well eh? (It is also fine if you don't want to do it - just close the PR)

John